### PR TITLE
Fix profile image URLs

### DIFF
--- a/frontend/src/components/common/Header.js
+++ b/frontend/src/components/common/Header.js
@@ -7,6 +7,9 @@ import profileService from '../../services/profileService';
 import notification from '../../utils/notification';
 import config from '../../config';
 
+// Base URL without the /api prefix for serving static assets
+const baseUrl = config.apiUrl.replace(/\/api$/, '');
+
 const Header = ({ title }) => {
   const { auth, logout } = useContext(AuthContext);
   const navigate = useNavigate();
@@ -159,7 +162,11 @@ const Header = ({ title }) => {
             data-show-dropdown={showDropdown}
           >            {auth.user.profileImage ? (
             <img
-              src={`${config.apiUrl}/uploads/profiles/${auth.user.profileImage}`}
+              src={
+                auth.user.profileImage.startsWith('/uploads/')
+                  ? `${baseUrl}${auth.user.profileImage}`
+                  : `${baseUrl}/uploads/profiles/${auth.user.profileImage}`
+              }
               alt="Profile"
               className="header-profile-avatar"
             />

--- a/frontend/src/components/profile/UserProfile.js
+++ b/frontend/src/components/profile/UserProfile.js
@@ -8,6 +8,9 @@ import ChangePasswordModal from '../auth/ChangePasswordModal';
 import profileService from '../../services/profileService';
 import notification from '../../utils/notification';
 import config from '../../config';
+
+// Base URL without the /api prefix for serving static assets
+const baseUrl = config.apiUrl.replace(/\/api$/, '');
 import './UserProfile.css';
 
 const UserProfile = () => {
@@ -72,8 +75,8 @@ const UserProfile = () => {
             if (profile.profileImage) {
                 // Backend returns full path like "/uploads/profiles/filename.jpg"
                 const imagePath = profile.profileImage.startsWith('/uploads/')
-                    ? `${config.apiUrl}${profile.profileImage}`
-                    : `${config.apiUrl}/uploads/profiles/${profile.profileImage}`;
+                    ? `${baseUrl}${profile.profileImage}`
+                    : `${baseUrl}/uploads/profiles/${profile.profileImage}`;
                 setImagePreview(imagePath);
             }
 
@@ -97,8 +100,8 @@ const UserProfile = () => {
             }); if (auth.user.profileImage) {
                 // Backend returns full path like "/uploads/profiles/filename.jpg"
                 const imagePath = auth.user.profileImage.startsWith('/uploads/')
-                    ? `${config.apiUrl}${auth.user.profileImage}`
-                    : `${config.apiUrl}/uploads/profiles/${auth.user.profileImage}`;
+                    ? `${baseUrl}${auth.user.profileImage}`
+                    : `${baseUrl}/uploads/profiles/${auth.user.profileImage}`;
                 setImagePreview(imagePath);
             }
         }
@@ -238,8 +241,8 @@ const UserProfile = () => {
             if (updatedProfile.profileImage) {
                 // Backend returns full path like "/uploads/profiles/filename.jpg"
                 const imagePath = updatedProfile.profileImage.startsWith('/uploads/')
-                    ? `${config.apiUrl}${updatedProfile.profileImage}`
-                    : `${config.apiUrl}/uploads/profiles/${updatedProfile.profileImage}`;
+                    ? `${baseUrl}${updatedProfile.profileImage}`
+                    : `${baseUrl}/uploads/profiles/${updatedProfile.profileImage}`;
                 setImagePreview(imagePath);
             }
 
@@ -262,8 +265,8 @@ const UserProfile = () => {
         // Set image preview with consistent path handling
         if (auth.user.profileImage) {
             const imagePath = auth.user.profileImage.startsWith('/uploads/')
-                ? `${config.apiUrl}${auth.user.profileImage}`
-                : `${config.apiUrl}/uploads/profiles/${auth.user.profileImage}`;
+                ? `${baseUrl}${auth.user.profileImage}`
+                : `${baseUrl}/uploads/profiles/${auth.user.profileImage}`;
             setImagePreview(imagePath);
         } else {
             setImagePreview(null);

--- a/frontend/src/components/profile/UserProfile.js
+++ b/frontend/src/components/profile/UserProfile.js
@@ -8,10 +8,10 @@ import ChangePasswordModal from '../auth/ChangePasswordModal';
 import profileService from '../../services/profileService';
 import notification from '../../utils/notification';
 import config from '../../config';
+import './UserProfile.css';
 
 // Base URL without the /api prefix for serving static assets
 const baseUrl = config.apiUrl.replace(/\/api$/, '');
-import './UserProfile.css';
 
 const UserProfile = () => {
     const { auth, updateUser } = useContext(AuthContext);

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,6 +1,10 @@
 
+const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+const baseUrl = apiUrl.replace(/\/api$/, '');
+
 const config = {
-  apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:5000/api',
+  apiUrl,
+  baseUrl,
   googleClientId: '312655720270-prcea14eek4i0abj09acomparvsipsq6.apps.googleusercontent.com',
   projectName: 'SS2-LMSHub'
 };


### PR DESCRIPTION
## Summary
- compute server base URL without `/api`
- use base URL to construct profile image paths

## Testing
- `npm test` (frontend) *(fails: Cannot find module 'react-router-dom')*
- `npm test` (backend) *(fails: Nest can't resolve dependencies of the AppController)*

------
https://chatgpt.com/codex/tasks/task_b_6841c9c2332483268245baff13d95e65